### PR TITLE
fix: build error in gcc 14

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <locale.h>
+#include <stdio.h>
 #include "main.h"
 #include "utils.h"
 


### PR DESCRIPTION
```
error: src/main.c:20:17: 错误：implicit declaration of function ‘perror’; did you mean ‘strerror’? [-Wimplicit-function-declaration]
   20 |                 perror("chdir");
      |                 ^~~~~~
      |                 strerror
  > in src/main.c
```